### PR TITLE
Move all logging out of the module

### DIFF
--- a/bin/checker.js
+++ b/bin/checker.js
@@ -19,42 +19,33 @@ colors.setTheme({
 console.log('Checking versions...'.info, '\n');
 
 checker().then(result => {
+    // check if the process should exit prematurely
     if (result.status != 0) {
         console.log(colors[result.message.type](result.message.text));
         process.exit(result.status);
     }
 
+    // print out results for each package
     result.packages.forEach(p => {
-        console.log(colors[p.type](p.name));
+        if (p.type === 'success') {
+            console.log(('✔ ' + colors.bold(p.name) + ' was validated with ' + p.expectedVersion).success);
+        }
+        else if (p.type === 'warn') {
+            console.log((colors.bold(p.name) + ' was expected, but no validator found!').warn);
+        }
+        else if (p.type === 'error' && p.commandError) {
+            console.log(('✘ Error validating ' + colors.bold(p.name) + ': ' + p.commandError).error);
+        }
+        else if (p.type === 'error' && !p.commandError) {
+            console.log(('✘ ' + colors.bold(p.name) + ' version is incorrect! Expected ' + p.expectedVersion + ' but was ' + p.foundVersion).error);
+        }
     });
 
+    // print out a summary message
     if (result.message.type === 'success') {
         console.log('\n', result.message.text.boldUnderlineSuccess);
     }
     else {
         console.log('\n', result.message.text.boldUnderlineError);
     }
-
-    process.exit(result.status);
 });
-
-// checkerResult.packages.push({
-//     message: "✔ " + colors.bold(name) + " was validated with " + engines[name],
-//     type: 'sucess'
-// });
-//
-// checkerResult.packages.push({
-//     message: colors.bold(name) + " was expected, but no validator found!",
-//     type: 'warn'
-// });
-//
-// checkerResult.packages.push({
-//     message: "✘ " + colors.bold(name) + " version is incorrect! Expected: " +
-//         engines[name] + " but was " + results.reason.trim(),
-//     type: 'error'
-// });
-//
-// checkerResult.packages.push({
-//     message: "✘ Error validating " + colors.bold(name) + ": " + error.trim(),
-//     type: 'error'
-// });

--- a/bin/checker.js
+++ b/bin/checker.js
@@ -3,4 +3,58 @@
 'use strict';
 
 const checker = require('../lib/checkSystem.js');
-checker();
+const colors = require('colors');
+
+// set color theme
+colors.setTheme({
+    success: 'green',
+    info: 'grey',
+    warn: 'yellow',
+    error: 'red',
+    boldWarn: ['bold', 'yellow'],
+    boldUnderlineSuccess: ['bold', 'underline', 'green'],
+    boldUnderlineError: ['bold', 'underline', 'red']
+});
+
+console.log('Checking versions...'.info, '\n');
+
+checker().then(result => {
+    if (result.status != 0) {
+        console.log(colors[result.message.type](result.message.text));
+        process.exit(result.status);
+    }
+
+    result.packages.forEach(p => {
+        console.log(colors[p.type](p.name));
+    });
+
+    if (result.message.type === 'success') {
+        console.log('\n', result.message.text.boldUnderlineSuccess);
+    }
+    else {
+        console.log('\n', result.message.text.boldUnderlineError);
+    }
+
+    process.exit(result.status);
+});
+
+// checkerResult.packages.push({
+//     message: "✔ " + colors.bold(name) + " was validated with " + engines[name],
+//     type: 'sucess'
+// });
+//
+// checkerResult.packages.push({
+//     message: colors.bold(name) + " was expected, but no validator found!",
+//     type: 'warn'
+// });
+//
+// checkerResult.packages.push({
+//     message: "✘ " + colors.bold(name) + " version is incorrect! Expected: " +
+//         engines[name] + " but was " + results.reason.trim(),
+//     type: 'error'
+// });
+//
+// checkerResult.packages.push({
+//     message: "✘ Error validating " + colors.bold(name) + ": " + error.trim(),
+//     type: 'error'
+// });

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -104,7 +104,7 @@ let check = function() {
             checkerResult.packages.push({
                 name: name,
                 validatorFound: true,
-                commandEror: error.trim(),
+                commandError: error.trim(),
                 type: 'error'
             });
             return Promise.reject();

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -41,7 +41,7 @@ let check = function() {
     const thingsToCheck = Object.getOwnPropertyNames(engines);
     const validatorPromises = thingsToCheck.map(validate); // run the function over all items.
 
-    promiseHelpers.allSettled(validatorPromises)
+    return promiseHelpers.allSettled(validatorPromises)
     .then((inspections) => {
         const environmentIsValid = _.every(inspections,
             (inspection) => inspection.isFulfilled() && inspection.value());

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -9,25 +9,29 @@ let check = function() {
     const fs = require('fs');
     let engines;
 
-    // set color theme
-    colors.setTheme({
-        success: 'green',
-        info: 'grey',
-        warn: 'yellow',
-        error: 'red'
-    });
+    const checkerResult = {
+        status: 0,
+        message: '',
+        packages: []
+    };
 
     try {
         fs.accessSync(process.cwd() + '/package.json');
         engines = require(process.cwd() + '/package.json').engines;
     } catch (ex) {
-        console.log("✘ No package.json found in the current directiry so I can't validate what you need!".error);
-        process.exit(-1);
+        checkerResult.message = {
+            text: "✘ No package.json found in the current directory so I can't validate what you need!",
+            type: 'error'
+        };
+        checkerResult.status = -1;
     }
 
     if (!engines) {
-        console.log("✘ No engines found in package.json so I can't validate what you need!".error);
-        process.exit(-1);
+        checkerResult.message = {
+            text: "✘ No engines found in package.json so I can't validate what you need!",
+            type: 'error'
+        };
+        checkerResult.status = -1;
     }
 
     let environmentValid = true;
@@ -35,7 +39,7 @@ let check = function() {
     const thingsToCheck = Object.getOwnPropertyNames(engines);
     var validators = thingsToCheck.map(validate); // run the function over all items.
 
-    Promise.all(validators.map(function(promise) {
+    return Promise.all(validators.map(function(promise) {
         return promise.reflect();
     })).each(function(inspection) {
         if (inspection.isFulfilled()) {
@@ -47,10 +51,17 @@ let check = function() {
         }
     }).then(() => {
         if (environmentValid) {
-            console.log(colors.success(colors.bold(colors.underline("Environment looks good!"))));
+            checkerResult.message = {
+                text: "Environment looks good!",
+                type: 'success'
+            };
         } else {
-            console.log(colors.error(colors.bold(colors.underline("Environment is invalid!"))));
+            checkerResult.message = {
+                text: "Environment is invalid!",
+                type: 'error'
+            };
         }
+        return checkerResult;
     });
 
     function validate(name) {
@@ -59,23 +70,43 @@ let check = function() {
         const validator = validaterRules[name];
 
         if (validator === undefined) {
-            console.log(colors.warn(colors.bold(name) + " was expected, but no validator found!"))
+            checkerResult.packages.push({
+                name: name,
+                validatorFound: false,
+                type: 'warn'
+            });
             return Promise.resolve(false);
         }
 
         //call the validator and pass in the version we expect
         return execAndCheck(validator, engines[name]).then((results) => {
             if (results.result) {
-                console.log(colors.success("✔ " + colors.bold(name) + " was validated with " + engines[name]));
+                checkerResult.packages.push({
+                    name: name,
+                    validatorFound: true,
+                    expectedVersion: engines[name],
+                    foundVersion: engines[name],
+                    type: 'success'
+                });
             } else {
-                console.log(colors.error("✘ " + colors.bold(name) + " version is not correct! Expected: " +
-                    engines[name] + " but was " + results.reason.trim()));
+                checkerResult.packages.push({
+                    name: name,
+                    validatorFound: true,
+                    expectedVersion: engines[name],
+                    foundVersion: results.reason.trim(),
+                    type: 'error'
+                });
             }
 
             return Promise.resolve(results.result);
         })
         .catch((error) => {
-            console.log(colors.error("✘ Error validating " + colors.bold(name)) + ": " + error.trim());
+            checkerResult.packages.push({
+                name: name,
+                validatorFound: true,
+                commandEror: error.trim(),
+                type: 'error'
+            });
             return Promise.reject();
         })
     }

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -28,6 +28,8 @@ let check = function() {
             type: 'error'
         };
         checkerResult.status = -1;
+
+        return Promise.resolve(checkerResult);
     }
 
     if (!engines) {
@@ -36,6 +38,8 @@ let check = function() {
             type: 'error'
         };
         checkerResult.status = -1;
+
+        return Promise.resolve(checkerResult);
     }
 
     const thingsToCheck = Object.getOwnPropertyNames(engines);


### PR DESCRIPTION
Closes issue #2. 

Changes
- (feature) `checkSystem` now returns a result object with all the collected information
- (feature) `checker` handles all the pretty printing
- (fix) return the main promise from `checkSystem` so that we get the result object
- (lint) changed spacing before function paren to never
- (lint) changed brace style to `stroustrup`

I can change the linting options back if necessary. 
