### PR TITLE
added validator for ios-webkit-debug-proxy

### DIFF
--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -108,6 +108,7 @@ let check = function(pathToPackage) {
             checkerResult.packages.push({
                 name: name,
                 validatorFound: true,
+                expectedVersion: engines[name],
                 commandError: error.trim(),
                 type: 'error'
             });

--- a/lib/checkSystem.spec.js
+++ b/lib/checkSystem.spec.js
@@ -72,7 +72,38 @@ test('checkSystem', (t) => {
 
         checkSystem().then((result) => {
             t.equal(result.message.type, 'error');
-            t.assert(_.some(result.packages, ['type', 'success']));
+            t.assert(result.packages[1].type, 'error');
+            t.assert(result.packages[0].type, 'success');
+            t.end();
+        });
+    });
+
+    t.test('when exec process errors, result package contains correct props', (t) => {
+
+        const testjson = {
+            engines: {
+                node: process.version
+            }
+        };
+
+        const checkSystem = proxyquire('./checkSystem', {
+            child_process : { 
+                exec: (command, cb) => { 
+                    // call the cb function with an error, but no stderr
+                    // (error, stdout, stderr)
+                    cb(-1, undefined, "");
+                }
+            },
+            jsonfile: { readFileSync: () => testjson }  
+        });
+
+        checkSystem().then((result) => {
+            t.equal(result.message.type, 'error');
+            t.equal(result.packages[0].name, 'node');
+            t.equal(result.packages[0].type, 'error');
+            t.equal(result.packages[0].validatorFound, true);
+            t.equal(result.packages[0].commandError, '');
+            t.equal(result.packages[0].expectedVersion, process.version);
             t.end();
         });
     });
@@ -87,8 +118,8 @@ test('checkSystem', (t) => {
 
         checkSystem().then((result) => {
             t.equal(result.message.type, 'error');
-            t.assert(_.some(result.packages, ['type', 'success']));
-            t.assert(_.some(result.packages, ['type', 'warn']));
+            t.assert(result.packages[1].type, 'warn');
+            t.assert(result.packages[0].type, 'success');
             t.end();
         });
     });

--- a/lib/validatorRules.js
+++ b/lib/validatorRules.js
@@ -45,8 +45,10 @@ module.exports = {
             (result, version) => version === result.trim()
     },
     "ios-webkit-debug-proxy": {
-        versionCheck: 'ios-webkit-debug-proxy',
+        versionCheck: 'brew list ios-webkit-debug-proxy --versions',
         versionValidate:
-            (result, version) => version === result.trim()
+            (result, version) => result.includes(version)
+            
     }
+
 };


### PR DESCRIPTION
- ios-webkit-debug-proxy validator - uses brew
- fixed bug with process errors, so that expected versions are still repored
- added unit test for process errors
- refactored some tests to better report errors

Closes #9 
