### PR TITLE
Changed exec to be a promise

### DIFF
--- a/bin/checker.js
+++ b/bin/checker.js
@@ -28,7 +28,7 @@ checker(process.argv[2]).then((result) => {
     // print out results for each package
     result.packages.forEach((p) => {
         if (p.type === 'success') {
-            console.log(('✔ ' + colors.bold(p.name) + ' was validated with ' + p.expectedVersion).success);
+            console.log(('✔ ' + colors.bold(p.name) + ' was validated with ' + p.expectedVersion + '.').success);
         }
         else if (p.type === 'warn') {
             console.log((colors.bold(p.name) + ' was expected, but no validator found!').warn);
@@ -40,7 +40,7 @@ checker(process.argv[2]).then((result) => {
             console.log((
                 '✘ ' + colors.bold(p.name) +
                 ' version is incorrect! Expected ' +
-                p.expectedVersion + ' but was ' + p.foundVersion
+                p.expectedVersion + ' but was ' + p.foundVersion + '.'
             ).error);
         }
     });

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -108,7 +108,7 @@ let check = function(pathToPackage) {
             checkerResult.packages.push({
                 name: name,
                 validatorFound: true,
-                commandError: error.trim(),
+                commandError: error,
                 type: 'error'
             });
             return Promise.reject();
@@ -116,29 +116,12 @@ let check = function(pathToPackage) {
     }
 
     function execAndCheck(validator, expectedVersion) {
-        // let promise = new Promise((resolve, reject) => {
-        //     exec(validator.versionCheck, (error, stdout, stderr) => {
-        //
-        //         if (error) {
-        //             reject(stderr);
-        //             return;
-        //         }
-        //
-        //         resolve({
-        //             result: validator.versionValidate(stdout, expectedVersion),
-        //             reason: stdout
-        //         });
-        //     });
-        // });
-        //
-        // return promise;
         return exec(validator.versionCheck).then((result) => {
-            console.log(result);
             return {
-                result: validator.versionValidate(result[0], expectedVersion),
-                reason: result[0]
+                result: validator.versionValidate(result, expectedVersion),
+                reason: result
             };
-        });
+        }).catch((e) => { throw e });
     }
 };
 module.exports = check;

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -97,7 +97,7 @@ let check = function(pathToPackage) {
                     name: name,
                     validatorFound: true,
                     expectedVersion: engines[name],
-                    foundVersion: results.reason.trim(),
+                    foundVersion: results.reason.trim() || 'missing',
                     type: 'error'
                 });
             }

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -121,7 +121,7 @@ let check = function(pathToPackage) {
                 result: validator.versionValidate(result, expectedVersion),
                 reason: result
             };
-        }).catch((e) => { throw e });
+        }).catch((e) => { throw e; });
     }
 };
 module.exports = check;

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -3,8 +3,8 @@
 let check = function(pathToPackage) {
 
     const path = require('path');
-    const exec = require('child_process').exec;
     const Promise = require('bluebird');
+    const exec = Promise.promisify(require('child_process').exec);
     const _ = require('lodash');
     const fs = require('fs');
     const jsonfile = require('jsonfile');
@@ -116,22 +116,29 @@ let check = function(pathToPackage) {
     }
 
     function execAndCheck(validator, expectedVersion) {
-        let promise = new Promise((resolve, reject) => {
-            exec(validator.versionCheck, (error, stdout, stderr) => {
-
-                if (error) {
-                    reject(stderr);
-                    return;
-                }
-
-                resolve({
-                    result: validator.versionValidate(stdout, expectedVersion),
-                    reason: stdout
-                });
-            });
+        // let promise = new Promise((resolve, reject) => {
+        //     exec(validator.versionCheck, (error, stdout, stderr) => {
+        //
+        //         if (error) {
+        //             reject(stderr);
+        //             return;
+        //         }
+        //
+        //         resolve({
+        //             result: validator.versionValidate(stdout, expectedVersion),
+        //             reason: stdout
+        //         });
+        //     });
+        // });
+        //
+        // return promise;
+        return exec(validator.versionCheck).then((result) => {
+            console.log(result);
+            return {
+                result: validator.versionValidate(result[0], expectedVersion),
+                reason: result[0]
+            };
         });
-
-        return promise;
     }
 };
 module.exports = check;

--- a/lib/checkSystem.spec.js
+++ b/lib/checkSystem.spec.js
@@ -87,14 +87,14 @@ test('checkSystem', (t) => {
         };
 
         const checkSystem = proxyquire('./checkSystem', {
-            child_process : { 
-                exec: (command, cb) => { 
+            child_process : {
+                exec: (command, cb) => {
                     // call the cb function with an error, but no stderr
                     // (error, stdout, stderr)
                     cb(-1, undefined, "");
                 }
             },
-            jsonfile: { readFileSync: () => testjson }  
+            jsonfile: { readFileSync: () => testjson }
         });
 
         checkSystem().then((result) => {
@@ -102,7 +102,7 @@ test('checkSystem', (t) => {
             t.equal(result.packages[0].name, 'node');
             t.equal(result.packages[0].type, 'error');
             t.equal(result.packages[0].validatorFound, true);
-            t.equal(result.packages[0].commandError, '');
+            t.equal(result.packages[0].commandError.toString(), 'Error: -1');
             t.equal(result.packages[0].expectedVersion, process.version);
             t.end();
         });


### PR DESCRIPTION
This closes #5.
- (feature) use `bluebird.promisify` to change the call to `exec` to return a promise
- (feature) updated the tests to check for the correct error returned
- (fix) some messages had punctuation, some didn't; unified that
- (fix) versions from `brew` were getting returned as empty when you don't have something installed, added a `'missing'` so it look better
