### PR TITLE
Validate Java and ant

### DIFF
--- a/lib/validatorRules.js
+++ b/lib/validatorRules.js
@@ -55,6 +55,11 @@ module.exports = {
         versionValidate:
             (result, version) => result.includes(version)
     },
+    java: {
+        versionCheck: 'javac -version 2>&1',
+        versionValidate:
+            (result, version) => result.includes(version)
+    },
     ant: {
         versionCheck: 'ant -version',
         versionValidate:

--- a/lib/validatorRules.js
+++ b/lib/validatorRules.js
@@ -54,7 +54,10 @@ module.exports = {
         versionCheck: 'brew list ideviceinstaller --versions',
         versionValidate:
             (result, version) => result.includes(version)
-
+    },
+    ant: {
+        versionCheck: 'ant -version',
+        versionValidate:
+            (result, version) => result.includes(version)
     }
-
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "adb": "1.0.36",
     "bower": "1.7.9",
     "ios-webkit-debug-proxy": "1.4_2",
-    "ideviceinstaller": "1.1.0_1"
+    "ideviceinstaller": "1.1.0_1",
+    "java": "1.8.0_31",
+    "ant": "1.9.4"
   },
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
This closes #14 and #13.
- (feature) added a validator for `java`
- (feature) added a validator for `ant`

**Note**: there is some weirdness with the validators. They don't print out just the version, they also include other text with it. Running `javac -version` returns `javac 1.8.0_74` and running `ant -version` returns `Apache Ant(TM) version 1.9.7 compiled on April 9 2016`. When the versions are correct, this doesn't cause a problem but when they're not, the message `...expected version x but got y` has all of that text in place of y (see example below). This is just because of what package devs decide to include in the version statements which may or may not always be a number. If we get into this, I could see this rabbit hole going pretty deep. Thoughts?

Example

```
✘ ant version is incorrect! Expected 1.9.4 but was Apache Ant(TM) version 1.9.7 compiled on April 9 2016
✘ java version is incorrect! Expected 1.8.0_31 but was javac 1.8.0_74
```
