### PR TITLE
Return non-zero exit code when any checker fails

### DIFF
--- a/bin/check-engine.js
+++ b/bin/check-engine.js
@@ -51,5 +51,6 @@ checker(process.argv[2]).then((result) => {
     }
     else {
         console.log('\n', result.message.text.boldUnderlineError);
+        process.exit(1);
     }
 });


### PR DESCRIPTION
Fix for #33.
For now, I'm just returning 1 when any checker fails.
