### PR TITLE
added a validator for windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,10 +9,6 @@ module.exports = {
             "error",
             4
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
         "quotes": [
             "off"
         ],

--- a/lib/validatorRules.js
+++ b/lib/validatorRules.js
@@ -80,5 +80,10 @@ module.exports = {
                 let found = result.match(/(\d+\.)?(\d+\.)?(\d+)/i);
                 return found[0] === version;
             }
+    },
+    windows: {
+        versionCheck: 'ver',
+        versionValidate:
+            (result, version) => result.includes(version)
     }
 };

--- a/lib/validatorRules.spec.js
+++ b/lib/validatorRules.spec.js
@@ -59,4 +59,19 @@ test('validatorRules', (t) => {
         });
     });
 
+    t.test('windows version', (t) => {
+        const checkSystem = setupChecker(
+            { engines: { windows: "10.0.14393" } },
+            "Microsoft Windows [Version 10.0.14393]"
+        );
+
+        checkSystem().then((result) => {
+            t.equal(result.packages[0].name, 'windows');
+            t.equal(result.packages[0].type, 'success');
+            t.equal(result.packages[0].validatorFound, true);
+            t.equal(result.packages[0].expectedVersion, result.packages[0].foundVersion);
+            t.end();
+        });
+    });
+
 });


### PR DESCRIPTION
Closes #28.

* (feature) validator for windows versions

Apparently, in our `.eslintrc.js`, we enforce unix style line breaks which breaks `npm run lint` on Windows. I thought it was something that we inherited from a template eslint ruleset but it's actually in our file. What should I do about this? The way that I have git configured actually changes my line endings from the windows style to the unix style while checking it in so `npm run lint` fails on my Windows machine but passes on travis. It's kind of a pain because eslint prints out an error for every line which runs out my command prompt buffer and it might hide actual errors. 

@mohlsen @kwpeters thoughts?