### PR TITLE
Updated engines settings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/mohlsen/check-engine#readme",
   "engines": {
-    "node": "8.6.0"
+    "node": ">=8.6.0"
   },
   "dependencies": {
     "bluebird": "3.5.3",


### PR DESCRIPTION
For yarn support in newer versions of node, because yarn check engines by default.