### PR TITLE
add option to ignore errors on process exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ check-engine can be installed globally or in a local directory.
 
 Simply run:
 
-`check-engine [path_to_package.json]`
+`check-engine [path_to_package.json] [options]`
 
 Where:
 
@@ -64,6 +64,12 @@ Where:
   file containing a list of [engines](https://docs.npmjs.com/files/package.json#engines)
   to validate.  If omitted, a package.json file will be looked
   for in the current working directory.
+
+and [options]:
+
+- `--ignore`: Ignore package validation errors and do not return an error exit code. Parsing issues or 
+  fatal errors will still return a error code.
+- `--help`: Display command line options
 
 **Note:** If check-engine is installed locally and you are not running it
 as part of an [npm script](https://docs.npmjs.com/misc/scripts), you will
@@ -87,7 +93,7 @@ checkEngine('<path to package.json>').then((result) => {
 
 ```
 
-The result object contains higher level status, as well as information for individual packages that were validated.  The above example only shows the high level. The object structure for the result object is as follows:
+The resolved object contains higher level status, as well as information for individual packages that were validated.  The above example only shows the high level. The object structure for the result object is as follows:
 
 ```javascript
 {
@@ -108,6 +114,7 @@ The result object contains higher level status, as well as information for indiv
     ]
 }
 ```
+
 For example usage of this, see [check-engine.js][check-engine-packages].
 
 ## Developing check-engine

--- a/bin/check-engine.js
+++ b/bin/check-engine.js
@@ -35,18 +35,28 @@ const commandLineOptions = [
                 description: 'Display this usage guide.',
                 alias: 'h',
                 type: Boolean
+            },
+            {
+                name: 'ignore',
+                description: 'Do not end the process with an exit code if there are errors validating packages.',
+                type: Boolean
             }
         ]
     }
 ];
 
 const usage = commandLineUsage(commandLineOptions);
-const argv = yargs(process.argv.slice(2)).help(false).argv;
+const argv = yargs(process.argv.slice(2))
+    .help(false)
+    .argv;
 
 if (argv.help || argv.h) {
     console.log(usage);
     process.exit(0);
 }
+
+const ignoreValidationErrors = argv.ignore;
+const fileToParse = argv._[0];
 
 // set color theme
 colors.setTheme({
@@ -61,7 +71,7 @@ colors.setTheme({
 
 console.log('Checking versions...'.info, '\n');
 
-checker(process.argv[2]).then((result) => {
+checker(fileToParse).then((result) => {
     // check if the process should exit prematurely
     if (result.status !== 0) {
         console.log(colors[result.message.type](result.message.text));
@@ -91,7 +101,9 @@ checker(process.argv[2]).then((result) => {
     // print out a summary message
     if (result.message.type !== 'success') {
         console.log('\n', result.message.text.boldUnderlineError);
-        process.exit(1);
+
+        ignoreValidationErrors === true ? process.exit(0) : process.exit(1);
+        
     }
 
     console.log('\n', result.message.text.boldUnderlineSuccess);

--- a/lib/checkSystem.js
+++ b/lib/checkSystem.js
@@ -25,7 +25,7 @@ let check = function(pathToPackage) {
     }
     catch (ex) {
         checkerResult.message = {
-            text: '✘ No package.json found in the current directory so I can\'t validate what you need!',
+            text: `✘ '${packageJsonPath}' not found in the current directory so I can't validate what you need!`,
             type: 'error'
         };
         checkerResult.status = -1;


### PR DESCRIPTION
Fixes #54 

Ability to use `--ignore` command line option to ignore validation errors and return a non error exit code.